### PR TITLE
Fix mainloop end error

### DIFF
--- a/ASLGameLog.py
+++ b/ASLGameLog.py
@@ -36,7 +36,7 @@ def command_menu():
     print("Press 9: Export to CSV")
     print("Press *: See Credits")
     print("Type \"End\": Exit the system")
-    command=input("Input command: ")
+    command=input("Input command: ").lower()
     if command=="1":
         #Show all records
         report_all()
@@ -63,7 +63,7 @@ def command_menu():
     elif command=="*":
         print_credits()
         return True
-    elif command=="End":
+    elif command=="end":
         export_csv()
         return False
     else:
@@ -388,7 +388,7 @@ def print_credits():
 con=sqlite3.connect('ASLgamelog.db')
 cur=con.cursor()
 
-#Create Table if needed 
+#Create Table if needed
 #Check if a table exists, if not, creates 'gamelog' Table
 cur.execute("SELECT count(name) FROM sqlite_master WHERE type='table' AND name='gamelog' ")
 if (cur.fetchone()[0])<1:
@@ -398,8 +398,6 @@ if (cur.fetchone()[0])<1:
 #Calling up the Command Menu
 
 while command_menu():
-    command_menu()
+    pass
 
 con.close()
-
-


### PR DESCRIPTION
If "End" command returned from command_menu() call in while loop body,
the program would not really end.

btw, consider using the standard "cmd" library https://docs.python.org/3/library/cmd.html
instead of "rolling your own". It takes care of boilerplate and common
issues. Such as above.

Also,

  - make commands case insensitive.